### PR TITLE
Feature: Conditional test groups

### DIFF
--- a/cms/grading/ScoreType.py
+++ b/cms/grading/ScoreType.py
@@ -209,7 +209,9 @@ class ScoreTypeGroup(ScoreTypeAlone):
     N_("N/A")
     TEMPLATE = """\
 {% for st in details %}
-    {% if "score_fraction" in st %}
+    {% if "score_ignore" in st %}
+<div class="subtask ignore">
+    {% elif "score_fraction" in st %}
         {% if st["score_fraction"] >= 1.0 %}
 <div class="subtask correct">
         {% elif st["score_fraction"] <= 0.0 %}

--- a/cms/grading/scoretypes/GroupSumCond.py
+++ b/cms/grading/scoretypes/GroupSumCond.py
@@ -39,7 +39,7 @@ class GroupSumCond(GroupSum):
         if u_score == 0:
             for st_idx, parameter in enumerate(self.parameters):
                 if parameter[2] == "C":
-                    st_score += subtasks[st_idx]["score_fraction"] * parameter[0]
+                    st_score = subtasks[st_idx]["score_fraction"] * parameter[0]
                     score -= st_score
                     subtasks[st_idx]["score_fraction"] = 0
                     if public_subtasks[st_idx] == subtasks[st_idx]:

--- a/cms/grading/scoretypes/GroupSumCond.py
+++ b/cms/grading/scoretypes/GroupSumCond.py
@@ -28,6 +28,7 @@ class GroupSumCond(GroupSum):
         for st_idx, parameter in enumerate(self.parameters):
             if parameter[2] == "C":
                 headers[st_idx] += " ***"
+        return score, public_score, headers
 
     def compute_score(self, submission_result):
         score, subtasks, public_score, public_subtasks, ranking_details = GroupSum.compute_score(self, submission_result)
@@ -41,7 +42,7 @@ class GroupSumCond(GroupSum):
                     st_score += subtasks[st_idx]["score_fraction"] * parameter[0]
                     score -= st_score
                     subtasks[st_idx]["score_fraction"] = 0
-                    if public_subtasks[st_idx] == subtasks[st_idx]
+                    if public_subtasks[st_idx] == subtasks[st_idx]:
                         public_score -= st_score
                     ranking_details[st_idx] = "0"
         return score, subtasks, public_score, public_subtasks, ranking_details

--- a/cms/grading/scoretypes/GroupSumCond.py
+++ b/cms/grading/scoretypes/GroupSumCond.py
@@ -15,11 +15,13 @@ class GroupSumCond(GroupSum):
     and each group score is the sum of testcase scores in the group,
     except the scores for "conditional" groups are only given if the
     solution gets at least some points for the "unconditional" groups.
-    Parameters are [[m, t, f], ... ]. The flag f must be one of "E", "U", "C":
-    "E" for examples that typically don't score any points,
-    "U" for unconditional group whose score is always given,
-    "C" for conditional group whose score is only given if the total for unconditional scores is non-zero.
-    See ScoreTypeGroup for m and t.
+    Parameters are [[m, t, f], ... ]. See ScoreTypeGroup for m and t.
+    The flag f must be one of "U", "C", "E":
+    "U" for unconditional group whose score is always counted,
+    "C" for conditional group whose score is only counted
+    if the total for unconditional scores is non-zero,
+    "E" for examples (these typically don't score points, but even
+    if they do, they do not affect the conditional groups).
 
     """
 
@@ -41,8 +43,8 @@ class GroupSumCond(GroupSum):
                 if parameter[2] == "C":
                     st_score = subtasks[st_idx]["score_fraction"] * parameter[0]
                     score -= st_score
-                    subtasks[st_idx]["score_fraction"] = 0
                     if public_subtasks[st_idx] == subtasks[st_idx]:
                         public_score -= st_score
                     ranking_details[st_idx] = "0"
+                    subtasks[st_idx]["score_ignore"] = True
         return score, subtasks, public_score, public_subtasks, ranking_details

--- a/cms/grading/scoretypes/GroupSumCond.py
+++ b/cms/grading/scoretypes/GroupSumCond.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from cms.grading.scoretypes.GroupSum import GroupSum
+
+import logging
+log = logging.getLogger(__name__)
+
+class GroupSumCond(GroupSum):
+    """The score of a submission is the sum of group scores,
+    and each group score is the sum of testcase scores in the group,
+    except the scores for "conditional" groups are only given if the
+    solution gets at least some points for the "unconditional" groups.
+    Parameters are [[m, t, f], ... ]. The flag f must be one of "E", "U", "C":
+    "E" for examples that typically don't score any points,
+    "U" for unconditional group whose score is always given,
+    "C" for conditional group whose score is only given if the total for unconditional scores is non-zero.
+    See ScoreTypeGroup for m and t.
+
+    """
+
+    def max_scores(self):
+        score, public_score, headers = GroupSum.max_scores(self)
+        for st_idx, parameter in enumerate(self.parameters):
+            if parameter[2] == "C":
+                headers[st_idx] += " ***"
+
+    def compute_score(self, submission_result):
+        score, subtasks, public_score, public_subtasks, ranking_details = GroupSum.compute_score(self, submission_result)
+        u_score = 0
+        for st_idx, parameter in enumerate(self.parameters):
+            if parameter[2] == "U":
+                u_score += subtasks[st_idx]["score_fraction"] * parameter[0]
+        if u_score == 0:
+            for st_idx, parameter in enumerate(self.parameters):
+                if parameter[2] == "C":
+                    st_score += subtasks[st_idx]["score_fraction"] * parameter[0]
+                    score -= st_score
+                    subtasks[st_idx]["score_fraction"] = 0
+                    if public_subtasks[st_idx] == subtasks[st_idx]
+                        public_score -= st_score
+                    ranking_details[st_idx] = "0"
+        return score, subtasks, public_score, public_subtasks, ranking_details

--- a/cms/grading/scoretypes/GroupSumCond.py
+++ b/cms/grading/scoretypes/GroupSumCond.py
@@ -34,17 +34,18 @@ class GroupSumCond(GroupSum):
 
     def compute_score(self, submission_result):
         score, subtasks, public_score, public_subtasks, ranking_details = GroupSum.compute_score(self, submission_result)
-        u_score = 0
-        for st_idx, parameter in enumerate(self.parameters):
-            if parameter[2] == "U":
-                u_score += subtasks[st_idx]["score_fraction"] * parameter[0]
-        if u_score == 0:
+        if len(subtasks) == len(self.parameters):
+            u_score = 0
             for st_idx, parameter in enumerate(self.parameters):
-                if parameter[2] == "C":
-                    st_score = subtasks[st_idx]["score_fraction"] * parameter[0]
-                    score -= st_score
-                    if public_subtasks[st_idx] == subtasks[st_idx]:
-                        public_score -= st_score
-                    ranking_details[st_idx] = "0"
-                    subtasks[st_idx]["score_ignore"] = True
+                if parameter[2] == "U":
+                    u_score += subtasks[st_idx]["score_fraction"] * parameter[0]
+            if u_score == 0:
+                for st_idx, parameter in enumerate(self.parameters):
+                    if parameter[2] == "C":
+                        st_score = subtasks[st_idx]["score_fraction"] * parameter[0]
+                        score -= st_score
+                        if public_subtasks[st_idx] == subtasks[st_idx]:
+                            public_score -= st_score
+                        ranking_details[st_idx] = "0"
+                        subtasks[st_idx]["score_ignore"] = True
         return score, subtasks, public_score, public_subtasks, ranking_details

--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -614,6 +614,10 @@ td.token_rules p:last-child {
     box-shadow: 0 0 2px 2px #D0D0D0 inset;
 }
 
+#submission_detail .subtask.ignored .subtask-head {
+    color: #707070;
+}
+
 #submission_detail .subtask.open .subtask-head {
     margin-bottom: 15px;
 }
@@ -650,6 +654,10 @@ td.token_rules p:last-child {
 
 #submission_detail .subtask.partiallycorrect .subtask-head .score {
     background-color: #edd400;
+}
+
+#submission_detail .subtask.ignored .subtask-head .score {
+    background-color: #707070;
 }
 
 #submission_detail .subtask:not(.open) .subtask-body {

--- a/cms/server/contest/static/cws_style.css
+++ b/cms/server/contest/static/cws_style.css
@@ -614,7 +614,7 @@ td.token_rules p:last-child {
     box-shadow: 0 0 2px 2px #D0D0D0 inset;
 }
 
-#submission_detail .subtask.ignored .subtask-head {
+#submission_detail .subtask.ignore .subtask-head {
     color: #707070;
 }
 
@@ -656,7 +656,7 @@ td.token_rules p:last-child {
     background-color: #edd400;
 }
 
-#submission_detail .subtask.ignored .subtask-head .score {
+#submission_detail .subtask.ignore .subtask-head .score {
     background-color: #707070;
 }
 

--- a/cmscontrib/loaders/estonia_yaml.py
+++ b/cmscontrib/loaders/estonia_yaml.py
@@ -519,6 +519,7 @@ class EstYamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                 subtasks = []
                 testcases = 0
                 points = None
+                parameters = []
                 for line in gen_file:
                     line = line.strip()
                     splitted = line.split('#', 1)
@@ -556,10 +557,12 @@ class EstYamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                             if points is None:
                                 assert(testcases == 0)
                             else:
-                                subtasks.append([points, testcases])
+                                subtasks.append([points, testcases] + parameters)
                             # Open the new one
                             testcases = 0
-                            points = int(comment[3:].strip())
+                            comment = [x.strip() for x in comment[3:].split()]
+                            points = int(comment[0])
+                            parameters = comment[1:]
 
                 # Close last subtask (if no subtasks were defined, just
                 # fallback to Sum)
@@ -572,11 +575,14 @@ class EstYamlLoader(ContestLoader, TaskLoader, UserLoader, TeamLoader):
                         input_value = total_value / n_input
                     args["score_type_parameters"] = input_value
                 else:
-                    subtasks.append([points, testcases])
+                    subtasks.append([points, testcases] + parameters)
                     #assert(100 == sum([int(st[0]) for st in subtasks]))
                     n_input = sum([int(st[1]) for st in subtasks])
-                    assert args["score_type"] in ["GroupMin", "GroupMul", "GroupSum", "GroupSumConditional", "GroupSumAtLeastTwo"]
-
+                    assert args["score_type"] in ["GroupMin", "GroupMul", "GroupSum", "GroupSumCond"]
+                    if args["score_type"] == "GroupSumCond":
+                        for st in subtasks:
+                            assert len(st) >= 3
+                            assert st[2] in ["E", "U", "C"]
                     args["score_type_parameters"] = subtasks
 
                 if "n_input" in conf:

--- a/setup.py
+++ b/setup.py
@@ -182,6 +182,7 @@ setup(
             "GroupMul=cms.grading.scoretypes.GroupMul:GroupMul",
             "GroupThreshold=cms.grading.scoretypes.GroupThreshold:GroupThreshold",
             "GroupSum=cms.grading.scoretypes.GroupSum:GroupSum",
+            "GroupSumCond=cms.grading.scoretypes.GroupSumCond:GroupSumCond",
         ],
         "cms.grading.languages": [
             "C++11 / g++=cms.grading.languages.cpp11_gpp:Cpp11Gpp",


### PR DESCRIPTION
Added feature to only count the score for some test groups when other groups get non-zero scores.

We need this in the beginner-oriented tasks in our local contests where we want to grant points for each positive test case (where the desired object can be constructed), but avoid giving points to solutions that only print out a constant negative result (such as 'NOT POSSIBLE'). For this, we have for many years used the grading condition "in this task, only those programs get points for negative test cases that solve correctly at least one positive test case".

This patch introduces the new `GroupSumCond` value for the `score_type` parameter in task configuration. For this scoring type, the `# ST: score` group header is extended to `# ST: score flag` where flag is one of:
`U` - unconditional group whose score is always counted (we put positive test cases here);
`C` - conditional group whose score is only counted if the total from unconditional groups is non-zero (we put negative test cases here);
`E` - examples (these typically do not score points anyway, but even if they do, they do not affect the conditional groups).